### PR TITLE
chore: refine Docker image tagging strategy for releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           images: ${{ github.repository }}
           flavor: |
-            latest=${{ github.event.release.prerelease == false }}
+            latest=${{ !github.event.release.prerelease }}
           tags: |
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !github.event.release.prerelease }}
+            type=semver,pattern={{major}},enable=${{ !github.event.release.prerelease }}
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
             type=sha,format=short
 
       - name: Set up QEMU 🦆

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           images: ${{ github.repository }}
           flavor: |
-            latest=true
+            latest=${{ github.event.release.prerelease == false }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,8 @@
 name: Docker Image
 
 on:
-  push:
-    tags: ['v*.*.*']
+  release:
+    types: [published]
 
 jobs:
   docker:


### PR DESCRIPTION
A mudança principal é garantir que as tags `latest`, `major` e `minor` sejam atualizadas apenas para releases completas, não para pré-releases.

## Impacto
- Usuários da tag 'latest' receberão apenas versões de release completas; e
- Pré-releases não serão mais marcadas como 'latest', nem `major` ou `minor`, proporcionando um ambiente mais estável e seguro.

## Exemplo

Se lançar uma tag com pré-release habilitado como `v1.6.9-beta`, o resultado será o seguinte:
1. `1.6.9-beta` (gerada pela regra type=semver,pattern={{version}})
2. `sha-abcdef1` (supondo que 'abcdef1' seja os primeiros 7 caracteres do SHA do commit)

Se for uma `release` final será atualizado todas as regras do `semver`.


## Evidências

Link: https://github.com/cubos/cli/actions/runs/11126593346/job/30916874908

![image](https://github.com/user-attachments/assets/8fe59b5f-e940-4b8d-9949-aca4961014b8)
![image](https://github.com/user-attachments/assets/c88e6b65-1f00-4ce4-ae4e-5683ae50eea4)

