### PR TITLE
fix: use `ImplementationSpecific` pathType for ingress

### DIFF
--- a/sites/deploy
+++ b/sites/deploy
@@ -283,7 +283,7 @@ K8S_YAML
 
 else
   cat <<K8S_YAML >> ingress.yaml
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: google-cloud-storage


### PR DESCRIPTION
- Due to the updates in version `v1.20.0` of Kubernetes Ingress Nginx, the `strict-validate-path-type` configuration has been enabled on many clusters, causing `pathType` validation to fail on deploys using `Prefix`.