### PR TITLE
feat: add labels spec at cron class on kube-templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22-alpine3.22
 
-RUN npm i -g ejs-cli ts-node@10.9.2 typescript@5.9.3 @cubos/kube-templates@1.0.1116470 @types/node@~24 firebase-tools && npm cache clean --force
+RUN npm i -g ejs-cli ts-node@10.9.2 typescript@5.9.3 @cubos/kube-templates@1.0.1124086 @types/node@~24 firebase-tools && npm cache clean --force
 
 RUN apk add --update docker libc6-compat libssl3 git nano openssh python3 py3-pip py3-cffi py3-cryptography findutils gettext bash jq ca-certificates moreutils curl ruby docker-cli openssl aws-cli php php-phar php-mbstring && \
     pip install --upgrade pip --break-system-packages && \


### PR DESCRIPTION
This pull request updates the Docker build process by bumping the version of `@cubos/kube-templates` to `1.0.1124086` in the `Dockerfile`. This ensures the container uses the latest features and fixes from that package.